### PR TITLE
Fix perms checks and Launch init to work with Win 7

### DIFF
--- a/ScriptPlayer/ScriptPlayer.Shared/Elevation/PermissionChecker.cs
+++ b/ScriptPlayer/ScriptPlayer.Shared/Elevation/PermissionChecker.cs
@@ -132,7 +132,7 @@ namespace ScriptPlayer.Shared.Elevation
 
             // https://deploywindows.info/2013/10/17/how-to-build-a-sddl-string-and-set-service-permissions/
             // https://social.msdn.microsoft.com/Forums/en-US/58da3fdb-a0e1-4161-8af3-778b6839f4e1/bluetooth-bluetoothledevicefromidasync-does-not-complete-on-10015063?forum=wdk#ef927009-676c-47bb-8201-8a80d2323a7f
-
+            // XXX: This line will throw on Windows 7, as the SDDI format used in this string is apparently not compatible there.
             RawSecurityDescriptor descriptor = new RawSecurityDescriptor("O:BAG:BAD:(A;;0x7;;;PS)(A;;0x3;;;SY)(A;;0x7;;;BA)(A;;0x3;;;AC)(A;;0x3;;;LS)(A;;0x3;;;NS)");
             byte[] data = new byte[descriptor.BinaryLength];
             descriptor.GetBinaryForm(data,0);

--- a/ScriptPlayer/ScriptPlayer/App.xaml.cs
+++ b/ScriptPlayer/ScriptPlayer/App.xaml.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Security.Principal;
 using System.Threading;
 using System.Windows;
+using Microsoft.Win32;
 using ScriptPlayer.Shared.Elevation;
 
 namespace ScriptPlayer
@@ -23,7 +24,25 @@ namespace ScriptPlayer
                     Debugger.Launch();
             }
 #endif
+            int _releaseId = 0;
+            try
+            {
+                _releaseId = int.Parse(Registry
+                    .GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion", "ReleaseId", string.Empty)
+                    .ToString());
+            }
+            catch (Exception)
+            {
+                // If we can't retreive a version, just skip the perm check entirely and don't allow Bluetooth usage.
+                Debug.WriteLine("Can't get version!");
+                return;
+            }
 
+            if (_releaseId < 1703)
+            {
+                // Version too low to use Bluetooth, skip check.
+                return;
+            }
             string exeName = Path.GetFileName(PermissionChecker.GetExe());
             Guid guid = Guid.NewGuid();
 

--- a/ScriptPlayer/ScriptPlayer/MainWindow.xaml
+++ b/ScriptPlayer/ScriptPlayer/MainWindow.xaml
@@ -198,7 +198,7 @@
             <MenuItem Header="Devices">
                 <MenuItem Header="Show Devices" Click="mnuShowDevices_Click"/>
                 <Separator/>
-                <MenuItem Header="Connect Launch directly" Command="{Binding ConnectLaunchDirectlyCommand}"/>
+                <MenuItem Header="Connect Launch Directly (Win10 15063+ Only)" Command="{Binding ConnectLaunchDirectlyCommand}" Name="LaunchDirectConnectItem" IsEnabled="False"/>
                 <MenuItem>
                     <MenuItem.Header>
                         <TextBlock>

--- a/ScriptPlayer/ScriptPlayer/MainWindow.xaml.cs
+++ b/ScriptPlayer/ScriptPlayer/MainWindow.xaml.cs
@@ -61,6 +61,7 @@ namespace ScriptPlayer
             ViewModel.RequestFile += ViewModelOnRequestFile;
             ViewModel.VideoPlayer = VideoPlayer;
             ViewModel.Load();
+            LaunchDirectConnectItem.IsEnabled = ViewModel.CanDirectConnectLaunch;
         }
 
         private void ViewModelOnRequestWhirligigConnectionSettings(object sender, RequestEventArgs<WhirligigConnectionSettings> args)


### PR DESCRIPTION
Windows 7 doesn't like the SDDI format of the bluetooth permissions string we need in the registry, and will also throw if it hits any code it can't deal with, like Win10 UWP stuff we use for bluetooth. Wrap these in version guards that will allow them to be skipped on anything < Win 10 15063.