### PR TITLE
Added video shift when settings panel is docked

### DIFF
--- a/ScriptPlayer/ScriptPlayer.Shared/Converters/BooleanToColumnSpanConverter.cs
+++ b/ScriptPlayer/ScriptPlayer.Shared/Converters/BooleanToColumnSpanConverter.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace ScriptPlayer.Shared.Converters
+{
+    public class BooleanToColumnSpanConverter : IValueConverter
+    {
+        public int OnTrue { get; set; } = int.MaxValue;
+        public int OnFalse { get; set; } = 1;
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value == null) 
+                return OnFalse;
+
+            return System.Convert.ToBoolean(value) ? OnTrue : OnFalse;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return Binding.DoNothing;
+        }
+    }
+}

--- a/ScriptPlayer/ScriptPlayer.Shared/ScriptPlayer.Shared.csproj
+++ b/ScriptPlayer/ScriptPlayer.Shared/ScriptPlayer.Shared.csproj
@@ -147,6 +147,7 @@
     <Compile Include="Classes\BlockingQueue.cs" />
     <Compile Include="Controls\AwesomeTextBlock.cs" />
     <Compile Include="Controls\PageSelector.cs" />
+    <Compile Include="Converters\BooleanToColumnSpanConverter.cs" />
     <Compile Include="Converters\SeekBarPositionConverter.cs" />
     <Compile Include="Devices\ButtplugAdapter.cs" />
     <Compile Include="Colors\ColorSampler.cs" />

--- a/ScriptPlayer/ScriptPlayer/MainWindow.xaml
+++ b/ScriptPlayer/ScriptPlayer/MainWindow.xaml
@@ -29,6 +29,7 @@
         <converters:ConversionModeToNameConverter x:Key="ConversionConverter"/>
         <converters1:DistinctValueToBooleanConverter x:Key="BooleanConverter"/>
         <converters1:TimeSpanToMillisecondsConverter x:Key="MillisecondsConverter"/>
+        <converters:BooleanToColumnSpanConverter x:Key="ColumnSpanConverter" OnFalse="1" OnTrue="2" />
         <converters:BooleanInverter x:Key="Inverter"/>
         <BooleanToVisibilityConverter x:Key="VisibilityConverter"/>
 
@@ -59,7 +60,8 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Grid Name="GridVideo"  Grid.Row="1"  Grid.ColumnSpan="2" Background="Black" MouseLeftButtonDown="VideoPlayer_OnMouseLeftButtonDown" AllowDrop="True" Drop="GridVideo_Drop">
+        <Grid Name="GridVideo" Grid.Row="1" Grid.ColumnSpan="{Binding ElementName=GridSettings, Path=(shared:HideOnHover.IsActive), Mode=OneWay, Converter={StaticResource ColumnSpanConverter}}"
+              Background="Black" MouseLeftButtonDown="VideoPlayer_OnMouseLeftButtonDown" AllowDrop="True" Drop="GridVideo_Drop">
             <!-- VIDEO PLAYER -->
             <shared:VideoPlayer Volume="{Binding Volume}" HideMouse="true" x:Name="VideoPlayer">
                 <shared:VideoPlayer.Style>
@@ -573,6 +575,7 @@
                 </shared:SeekBar.Style>
             </shared:SeekBar>
         </DockPanel>
+
         <Grid Name="GridSettings" shared:HideOnHover.IsActive="True" Width="180" Background="White" Grid.Column="1" HorizontalAlignment="Stretch" Margin="0" Grid.Row="1" VerticalAlignment="Stretch">
             <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
                 <Grid>


### PR DESCRIPTION
This change prevents the video from being overlapped when the settings panel has been docked (autohide disabled).