### PR TITLE
Improved Vorze compatibility

### DIFF
--- a/ScriptPlayer/ScriptPlayer.Shared/Devices/ButtplugAdapter.cs
+++ b/ScriptPlayer/ScriptPlayer.Shared/Devices/ButtplugAdapter.cs
@@ -155,7 +155,8 @@ namespace ScriptPlayer.Shared
                 }
                 else if (device.AllowedMessages.ContainsKey(nameof(VorzeA10CycloneCmd)))
                 {
-                    message = new VorzeA10CycloneCmd(device.Index, CommandConverter.LaunchToVorzeSpeed(information), information.PositionToTransformed > information.PositionFromTransformed);
+                    // position is used as speed here
+                    message = new VorzeA10CycloneCmd(device.Index, CommandConverter.SimpleVorzeSpeed(information), information.PositionFromOriginal > 50);
                 }
                 else if (device.AllowedMessages.ContainsKey(nameof(LovenseCmd)))
                 {

--- a/ScriptPlayer/ScriptPlayer.Shared/Devices/CommandConverter.cs
+++ b/ScriptPlayer/ScriptPlayer.Shared/Devices/CommandConverter.cs
@@ -4,7 +4,7 @@ namespace ScriptPlayer.Shared
 {
     public static class CommandConverter
     {
-        public static uint LaunchToVorzeSpeed(DeviceCommandInformation info)
+        /*public static uint LaunchToVorzeSpeed(DeviceCommandInformation info)
         {
             //Information from https://github.com/metafetish/syncydink/blob/4c8c31d6f8ffba2c9d1f3fcb69209630b209cd89/src/utils/HapticsToButtplug.ts#L186
 
@@ -12,6 +12,14 @@ namespace ScriptPlayer.Shared
             double speed = Math.Floor(25000 * Math.Pow(info.Duration.TotalMilliseconds / delta, -1.05)) / 100.0;
             // 100ms = ~0.95
             speed = info.TransformSpeed(speed) * 100.0;
+
+            return (uint)speed;
+        }*/
+
+        public static uint SimpleVorzeSpeed(DeviceCommandInformation info)
+        {
+            double speed = Math.Abs(info.PositionFromOriginal - 50) / 50.0;
+            speed = info.TransformSpeed(speed) * 99.0;
 
             return (uint)speed;
         }

--- a/ScriptPlayer/ScriptPlayer.Shared/Scripts/VorzeToFunscriptConverter.cs
+++ b/ScriptPlayer/ScriptPlayer.Shared/Scripts/VorzeToFunscriptConverter.cs
@@ -27,7 +27,8 @@ namespace ScriptPlayer.Shared.Scripts
 
             for (int i = 0; i < actions.Count; i++)
             {
-                int samePosition = 0;
+                // removed because vorze rotation speed changes while still rotating in the same direction are an essential feature
+                /*int samePosition = 0;
 
                 for (int j = i + 1; j < actions.Count; j++)
                 {
@@ -35,12 +36,13 @@ namespace ScriptPlayer.Shared.Scripts
                         samePosition++;
                     else
                         break;
-                }
+                }*/
 
+                // This has been modified to make Vorze CSVs round-trip better through the conversions, but other toys should still get something out of this too
                 funActions.Add(new FunScriptAction
                 {
-                    Position = (byte)(actions[i].Action == 0 ? 95 : 5),
-                    TimeStamp = actions[i + samePosition].TimeStamp
+                    Position = (byte)(50 + actions[i].Parameter * (actions[i].Action == 0 ? 0.5 : -0.5)),
+                    TimeStamp = actions[i].TimeStamp
                 });
             }
 


### PR DESCRIPTION
The old code for converting Vorze .csv files to funscript packets lost some information that was necessary for generating the intended motions on an actual Vorze device, so I made a quick change to both the CSV reading and the Vorze device controlling parts. 

Running Launch scripts on a Vorze still produces decent, if different from intended, results, but currently this might make Vorze scripts kind of boring on a Launch. Using position values as speed values is okay, but using speed values as position values makes things boring. I don't have a Launch to test what kind of filler should be added to fix this. 

An ideal solution would be one that retains the information needed to play the original Vorze script 1:1, but generates good patterns when converted both ways. For this, it might be required to store information about the original script format so different conversions can be used in different contexts.

Eventually adding user options to adjust the conversion would be good, too.