### PR TITLE
Force a single instance of ScriptPlayer

### DIFF
--- a/ScriptPlayer/ScriptPlayer/MainWindow.xaml.cs
+++ b/ScriptPlayer/ScriptPlayer/MainWindow.xaml.cs
@@ -47,7 +47,7 @@ namespace ScriptPlayer
         public MainWindow()
         {
             bool createdNew = true;
-            SingleInstanceMutex = new Mutex(true, "ScriptPlayer", out createdNew);
+            SingleInstanceMutex = new Mutex(true, "ScriptPlayerInstance", out createdNew);
             if(!createdNew)
             {
                 // another instance is already running

--- a/ScriptPlayer/ScriptPlayer/MainWindow.xaml.cs
+++ b/ScriptPlayer/ScriptPlayer/MainWindow.xaml.cs
@@ -89,7 +89,6 @@ namespace ScriptPlayer
 
         private void PipeConnection(IAsyncResult result)
         {
-            Console.WriteLine("connection");
             PipeServer.EndWaitForConnection(result);
             using(StreamReader reader = new StreamReader(PipeServer))
             {


### PR DESCRIPTION
Hello it's me again.

I thought it would make sense for ScriptPlayer to always just have one open instance.
My changes make it so that you can for example set in windows explorer ScriptPlayer as the default program to open funscript files, so that when open one from the explorer it it will automaticly load the script in the current instance of ScriptPlayer instead of spawning a new process.
personally I think that's pretty cool 😎