### PR TITLE
fix tiny bug in ExtendRange

### DIFF
--- a/ScriptPlayer/ScriptPlayer.Shared/Scripts/ScriptHandler.cs
+++ b/ScriptPlayer/ScriptPlayer.Shared/Scripts/ScriptHandler.cs
@@ -434,12 +434,12 @@ namespace ScriptPlayer.Shared.Scripts
                         goingUp ^= true;
                     }
 
-                    lastValue = _filledActions[index].Position;
-                    if (lastValue > highest)
-                        highest = lastValue;
-                    if (lastValue < lowest)
-                        lowest = lastValue;
                 }
+                lastValue = _filledActions[index].Position;
+                if (lastValue > highest)
+                    highest = lastValue;
+                if (lastValue < lowest)
+                    lowest = lastValue;
             }
 
             extendedActions.Add(_filledActions.Last().Duplicate());


### PR DESCRIPTION
Hey,
I was stealing the range extender code for OFS and found tiny bug.
Here's a script you can use to see the bug https://pastebin.com/ZrCWbXDi at 4 seconds.
The first down stroke gets skipped that's all. 
Nobody using ScriptPlayer would've ever noticed that. 😅 