### PR TITLE
Fix the loading of E-Stim Audio files when viewing video through an external player.

### DIFF
--- a/ScriptPlayer/ScriptPlayer/ViewModels/MainViewModel.cs
+++ b/ScriptPlayer/ScriptPlayer/ViewModels/MainViewModel.cs
@@ -1112,6 +1112,10 @@ namespace ScriptPlayer.ViewModels
             TryFindMatchingScript(videoFileName);
             TryFindMatchingThumbnails(videoFileName, true);
 
+            // We meed to explicitly reload the audio file because the time source does not change when file on remote player changes
+
+            ReloadAudio(videoFileName);
+            
             UpdateGeneratorPriority();
         }
 
@@ -1901,9 +1905,9 @@ namespace ScriptPlayer.ViewModels
             _audioHandler.Delay = Settings.AudioDelay;
         }
 
-        private void ReloadAudio()
+        private void ReloadAudio(string VideoFileName = null)
         {
-            TryFindMatchingAudio(LoadedVideo);
+            TryFindMatchingAudio(LoadedVideo ?? VideoFileName);
             if(TimeSource?.IsPlaying ?? false)
                 _audioHandler?.Play();
 


### PR DESCRIPTION
Audio loading was ony implemented in LoadVideo which only gets called on local playback. Also, audio will not start playing after load, because unlike with loading another local video file, the time source does not change when the remote player loads a new file. 

Should fix Issue 152.