### PR TITLE
Decrease Minimum "Min Command Delay" to 1ms

### DIFF
--- a/ScriptPlayer/ScriptPlayer/Dialogs/SettingsDialog.xaml
+++ b/ScriptPlayer/ScriptPlayer/Dialogs/SettingsDialog.xaml
@@ -721,7 +721,7 @@
                             <DockPanel Margin="4" ToolTip="Minimal delay between two script commands">
                                 <TextBlock Style="{StaticResource SettingName}" Text="Min Command Delay"/>
                                 <TextBlock Style="{StaticResource SettingValue}" Text="{Binding Path=Settings.CommandDelay, Converter={StaticResource MillisecondsConverter}, StringFormat={}{0:f0} ms}"/>
-                                <Slider LargeChange="5" Margin="0,4" Minimum="1" Maximum="50"  Value="{Binding Path=Settings.CommandDelay, Converter={StaticResource MillisecondsConverter}}"  SmallChange="1"  IsSnapToTickEnabled="True" TickFrequency="1"/>
+                                <Slider LargeChange="5" Margin="0,4" Minimum="1" Maximum="250"  Value="{Binding Path=Settings.CommandDelay, Converter={StaticResource MillisecondsConverter}}"  SmallChange="1"  IsSnapToTickEnabled="True" TickFrequency="1"/>
                             </DockPanel>
                         </StackPanel>
                     </Grid>

--- a/ScriptPlayer/ScriptPlayer/Dialogs/SettingsDialog.xaml
+++ b/ScriptPlayer/ScriptPlayer/Dialogs/SettingsDialog.xaml
@@ -721,7 +721,7 @@
                             <DockPanel Margin="4" ToolTip="Minimal delay between two script commands">
                                 <TextBlock Style="{StaticResource SettingName}" Text="Min Command Delay"/>
                                 <TextBlock Style="{StaticResource SettingValue}" Text="{Binding Path=Settings.CommandDelay, Converter={StaticResource MillisecondsConverter}, StringFormat={}{0:f0} ms}"/>
-                                <Slider LargeChange="1" Margin="0,4" Minimum="10" Maximum="300"  Value="{Binding Path=Settings.CommandDelay, Converter={StaticResource MillisecondsConverter}}"  SmallChange="1"  IsSnapToTickEnabled="True" TickFrequency="1"/>
+                                <Slider LargeChange="5" Margin="0,4" Minimum="1" Maximum="50"  Value="{Binding Path=Settings.CommandDelay, Converter={StaticResource MillisecondsConverter}}"  SmallChange="1"  IsSnapToTickEnabled="True" TickFrequency="1"/>
                             </DockPanel>
                         </StackPanel>
                     </Grid>

--- a/ScriptPlayer/ScriptPlayer/MainWindow.xaml
+++ b/ScriptPlayer/ScriptPlayer/MainWindow.xaml
@@ -770,7 +770,7 @@
 
                                     <StackPanel Margin="4" ToolTip="Minimal delay between two script commands">
                                         <TextBlock Margin="0" Text="Min Command Delay" TextAlignment="Center"/>
-                                        <Slider LargeChange="1" Margin="0,4" Minimum="10" Maximum="300"  Value="{Binding Path=Settings.CommandDelay, Converter={StaticResource MillisecondsConverter}}"  SmallChange="1"  IsSnapToTickEnabled="True" TickFrequency="1"/>
+                                        <Slider LargeChange="5" Margin="0,4" Minimum="1" Maximum="50"  Value="{Binding Path=Settings.CommandDelay, Converter={StaticResource MillisecondsConverter}}"  SmallChange="1"  IsSnapToTickEnabled="True" TickFrequency="1"/>
                                         <TextBlock Margin="0" Text="{Binding Path=Settings.CommandDelay, Converter={StaticResource MillisecondsConverter}, StringFormat={}{0:f0} ms}" TextAlignment="Center"/>
                                     </StackPanel>
 

--- a/ScriptPlayer/ScriptPlayer/MainWindow.xaml
+++ b/ScriptPlayer/ScriptPlayer/MainWindow.xaml
@@ -770,7 +770,7 @@
 
                                     <StackPanel Margin="4" ToolTip="Minimal delay between two script commands">
                                         <TextBlock Margin="0" Text="Min Command Delay" TextAlignment="Center"/>
-                                        <Slider LargeChange="5" Margin="0,4" Minimum="1" Maximum="50"  Value="{Binding Path=Settings.CommandDelay, Converter={StaticResource MillisecondsConverter}}"  SmallChange="1"  IsSnapToTickEnabled="True" TickFrequency="1"/>
+                                        <Slider LargeChange="5" Margin="0,4" Minimum="1" Maximum="250"  Value="{Binding Path=Settings.CommandDelay, Converter={StaticResource MillisecondsConverter}}"  SmallChange="1"  IsSnapToTickEnabled="True" TickFrequency="1"/>
                                         <TextBlock Margin="0" Text="{Binding Path=Settings.CommandDelay, Converter={StaticResource MillisecondsConverter}, StringFormat={}{0:f0} ms}" TextAlignment="Center"/>
                                     </StackPanel>
 


### PR DESCRIPTION
Recent reports on EroScripts ([ref](https://discuss.eroscripts.com/t/script-player-handy-over-bluetooth-firmware-3-much-better-expirience/31837/48)) show that users have been having issues with scripts that aren't slow or simple, when using The Handy over Bluetooth. Experimentation ultimately shows that the minimum command delay is causing jerkiness and missed commands.

My solution here, of reducing the minimum to 1ms, is admittedly based around not really understanding the purpose of the minimum command delay; I'm not really sure what that's for, where the advantage is to having this in places is. But I've presumed that the lower end of the range is the useful part, at least on modern hardware, so I've brought down the max to 50ms as well in order to facilitate easier configuration (ergo, reduce the precision required to set a specific min command delay setting).

Anywoo, a min command delay of 1ms makes The Handy usable and accurate over Bluetooth for even rather rapid scripts.