### PR TITLE
Improve output of estim mp3 files

### DIFF
--- a/ScriptPlayer/ScriptPlayer.Shared/TimeSource/AudioFileTimeSource.cs
+++ b/ScriptPlayer/ScriptPlayer.Shared/TimeSource/AudioFileTimeSource.cs
@@ -46,7 +46,7 @@ namespace ScriptPlayer.Shared
 
             _waveOut = new WaveOut(WaveCallbackInfo.FunctionCallback());
             _waveOut.DeviceNumber = GetDeviceNumber(device);
-            _waveOut.DesiredLatency = 100;
+            _waveOut.DesiredLatency = 150;
             _waveOut.Init(_baStream);
         }
 
@@ -113,7 +113,7 @@ namespace ScriptPlayer.Shared
 
         public void Resync(TimeSpan timeSpan)
         {
-            _position = timeSpan - Delay + TimeSpan.FromMilliseconds(_waveOut.DesiredLatency);
+            _position = timeSpan - Delay;
 
             if (_position >= _rdr.TotalTime)
             {
@@ -121,7 +121,7 @@ namespace ScriptPlayer.Shared
                 return;
             }
 
-            double maxDesync = TimeSpan.FromMilliseconds(50).TotalSeconds;
+            double maxDesync = TimeSpan.FromMilliseconds(_waveOut.DesiredLatency).TotalSeconds;
             TimeSpan currentPosition = _rdr.CurrentTime;
             TimeSpan desync = currentPosition - _position;
             if (Math.Abs(desync.TotalSeconds) > maxDesync)

--- a/ScriptPlayer/ScriptPlayer.Shared/TimeSource/AudioFileTimeSource.cs
+++ b/ScriptPlayer/ScriptPlayer.Shared/TimeSource/AudioFileTimeSource.cs
@@ -46,7 +46,7 @@ namespace ScriptPlayer.Shared
 
             _waveOut = new WaveOut(WaveCallbackInfo.FunctionCallback());
             _waveOut.DeviceNumber = GetDeviceNumber(device);
-            _waveOut.DesiredLatency = 50;
+            _waveOut.DesiredLatency = 100;
             _waveOut.Init(_baStream);
         }
 
@@ -113,7 +113,7 @@ namespace ScriptPlayer.Shared
 
         public void Resync(TimeSpan timeSpan)
         {
-            _position = timeSpan - Delay;
+            _position = timeSpan - Delay + TimeSpan.FromMilliseconds(_waveOut.DesiredLatency);
 
             if (_position >= _rdr.TotalTime)
             {


### PR DESCRIPTION
I noticed this user of ScriptPlayer has same issue as me (cracking/buffering noise): [Milovana ScriptPlayer thread post](https://milovana.com/forum/viewtopic.php?p=287840#p287840)

I recognized issue with too low buffer as I know how my VoiceMeeter output sounded when I reduced latency too much.

So I decided to find the latency and see if increasing it works instead of opening a bug. I tested this locally and I am now using my build because with 50ms all files are painful :)