### PR TITLE
Small bugfix and one suggestion

### DIFF
--- a/ScriptPlayer/ScriptPlayer.Shared/Devices/Estim/FunstimSampleProvider.cs
+++ b/ScriptPlayer/ScriptPlayer.Shared/Devices/Estim/FunstimSampleProvider.cs
@@ -98,8 +98,16 @@ class FunstimSampleProvider : ISampleProvider
                     }
                 }
 
-                // fade in
-                volume = (volume * (filterLength - 1) + targetVolume) / filterLength;
+                // fade in (unless fade time is 0)
+
+                if (filterLength > 0)
+                {
+                    volume = (volume * (filterLength - 1) + targetVolume) / filterLength;
+                }
+                else
+                {
+                    volume = 1.0f;
+                }
             }
 
             if (volume > 1.0f)

--- a/ScriptPlayer/ScriptPlayer.Shared/Devices/Estim/FunstimSampleProvider.cs
+++ b/ScriptPlayer/ScriptPlayer.Shared/Devices/Estim/FunstimSampleProvider.cs
@@ -106,7 +106,7 @@ class FunstimSampleProvider : ISampleProvider
                 }
                 else
                 {
-                    volume = 1.0f;
+                    volume = targetVolume;
                 }
             }
 

--- a/ScriptPlayer/ScriptPlayer.Shared/Devices/Estim/FunstimSampleProvider.cs
+++ b/ScriptPlayer/ScriptPlayer.Shared/Devices/Estim/FunstimSampleProvider.cs
@@ -42,7 +42,7 @@ class FunstimSampleProvider : ISampleProvider
     {
         int diff = Math.Abs((int)timer.ElapsedMilliseconds - this.durationMs);
 
-        if (diff > 100 || startPosition != this.endPosition)
+        if (diff > 100 || Math.Abs(startPosition - this.endPosition)>10)
         {
             Debug.WriteLine("diff: " + diff);
             Debug.WriteLine("start: " + startPosition + ", previous end: " + this.endPosition);


### PR DESCRIPTION
Hi!

This pull request has two small changes to the FunStimSampleProvider. The first change fixes a division by zero that occurs when you set the fade time to 0ms. 

The second change is a suggestion, which makes the skip protection a little bit more tolerant to "vibration patterns" that are becoming somewhat popular in the handy community recently, which use very short-spaced commands that result in actions that never quite reach their target value because the read function can't react faster to actions than the runtime of one audio buffer.