### PR TITLE
Experimental Volume Ramping feature for FunStimAudioDevice

### DIFF
--- a/ScriptPlayer/ScriptPlayer.Shared/Devices/DeviceCommandInformation.cs
+++ b/ScriptPlayer/ScriptPlayer.Shared/Devices/DeviceCommandInformation.cs
@@ -12,6 +12,9 @@ namespace ScriptPlayer.Shared
         public byte PositionToOriginal;
         public byte SpeedOriginal;
 
+        public TimeSpan TimeStamp;
+        public TimeSpan MediaDuration;
+
         public TimeSpan Duration;
         public double SpeedMultiplier { get; set; } = 1;
         public double SpeedMin { get; set; } = 0;

--- a/ScriptPlayer/ScriptPlayer.Shared/Devices/Estim/FunstimAudioDevice.cs
+++ b/ScriptPlayer/ScriptPlayer.Shared/Devices/Estim/FunstimAudioDevice.cs
@@ -21,7 +21,7 @@ namespace ScriptPlayer.Shared.Estim
             {
                 List<int> frequencies = Array.ConvertAll(parameters.Frequencies.Split(','), int.Parse).Where(x => x != 0).ToList();
 
-                _provider = new FunstimSampleProvider(frequencies, (int)parameters.FadeMs.TotalMilliseconds, parameters.FadeOnPause);
+                _provider = new FunstimSampleProvider(frequencies, (int)parameters.FadeMs.TotalMilliseconds, (int)parameters.RampPercent, parameters.FadeOnPause);
 
                 _soundOut.Init(_provider);
                 _soundOut.Play();
@@ -46,7 +46,7 @@ namespace ScriptPlayer.Shared.Estim
 
         protected override Task Set(DeviceCommandInformation information)
         {
-            _provider?.Action(information.PositionFromTransformed, information.PositionToTransformed, (int)information.Duration.TotalMilliseconds, information.SpeedMultiplier);
+            _provider?.Action(information.PositionFromTransformed, information.PositionToTransformed, (int)information.Duration.TotalMilliseconds, information.SpeedMultiplier, information.TimeStamp, information.MediaDuration);
             return Task.CompletedTask;
         }
 
@@ -71,6 +71,7 @@ namespace ScriptPlayer.Shared.Estim
     {
         public string Frequencies { get; set; }
         public TimeSpan FadeMs { get; set; }
+        public int RampPercent { get; set; }
         public bool FadeOnPause { get; set; }
     }
 }

--- a/ScriptPlayer/ScriptPlayer.Shared/Devices/Estim/FunstimSampleProvider.cs
+++ b/ScriptPlayer/ScriptPlayer.Shared/Devices/Estim/FunstimSampleProvider.cs
@@ -98,8 +98,16 @@ class FunstimSampleProvider : ISampleProvider
                     }
                 }
 
-                // fade in
-                volume = (volume * (filterLength - 1) + targetVolume) / filterLength;
+                // fade in (unless fade time is 0)
+
+                if (filterLength > 0)
+                {
+                    volume = (volume * (filterLength - 1) + targetVolume) / filterLength;
+                }
+                else
+                {
+                    volume = 1.0f;
+                }
             }
 
             if (volume > 1.0f)

--- a/ScriptPlayer/ScriptPlayer.Shared/Devices/Estim/FunstimSampleProvider.cs
+++ b/ScriptPlayer/ScriptPlayer.Shared/Devices/Estim/FunstimSampleProvider.cs
@@ -106,7 +106,7 @@ class FunstimSampleProvider : ISampleProvider
                 }
                 else
                 {
-                    volume = 1.0f;
+                    volume = targetVolume;
                 }
             }
 

--- a/ScriptPlayer/ScriptPlayer.Shared/Devices/Estim/FunstimSampleProvider.cs
+++ b/ScriptPlayer/ScriptPlayer.Shared/Devices/Estim/FunstimSampleProvider.cs
@@ -16,6 +16,10 @@ class FunstimSampleProvider : ISampleProvider
     private long sampleCount;
     private long startSample;
 
+    private float startRamp;
+    private float endRamp;
+    private float scaleRamp;
+
     private int startPosition;
     private int endPosition;
     private int durationMs;
@@ -23,12 +27,13 @@ class FunstimSampleProvider : ISampleProvider
     private double speedMultiplier;
     private float volume = 0.0f;
 
-    public FunstimSampleProvider(List<int> frequencies, int fadeMs, bool fadeOnPause, int sampleRate = 44100)
+    public FunstimSampleProvider(List<int> frequencies, int fadeMs, int rampPercent, bool fadeOnPause, int sampleRate = 44100)
     {
         this.radsPerSample = frequencies.ConvertAll(f => (f * Math.PI * 2) / sampleRate);
         this.fadeSamples = (fadeMs * sampleRate) / 1000.0f;
         this.sampleRate = sampleRate;
         this.fadeOnPause = fadeOnPause;
+        this.scaleRamp = rampPercent/100.0f;
 
         numSamples = 1;
         sampleCount = (int)fadeSamples * 10;
@@ -38,7 +43,7 @@ class FunstimSampleProvider : ISampleProvider
         WaveFormat = WaveFormat.CreateIeeeFloatWaveFormat(sampleRate, 2);
     }
 
-    public void Action(int startPosition, int endPosition, int durationMs, double speedMultiplier)
+    public void Action(int startPosition, int endPosition, int durationMs, double speedMultiplier, TimeSpan timeStamp, TimeSpan mediaDuration)
     {
         int diff = Math.Abs((int)timer.ElapsedMilliseconds - this.durationMs);
 
@@ -55,6 +60,9 @@ class FunstimSampleProvider : ISampleProvider
         this.durationMs = durationMs;
         this.speedMultiplier = speedMultiplier;
 
+        this.startRamp = (float) (timeStamp.TotalMilliseconds / mediaDuration.TotalMilliseconds) * scaleRamp + (1-scaleRamp);
+        this.endRamp = (float) ((timeStamp.TotalMilliseconds + durationMs) / mediaDuration.TotalMilliseconds) * scaleRamp + (1-scaleRamp);
+
         numSamples = (durationMs * sampleRate) / 1000;
 
         timer.Restart();
@@ -70,11 +78,14 @@ class FunstimSampleProvider : ISampleProvider
         {
             long sample = sampleCount - startSample;
             double position = (sample * endPosition + (numSamples - sample) * startPosition) / numSamples;
+            float rampVolume = (sample * endRamp + (numSamples - sample) * startRamp) / numSamples;
+
             int filterLength = (int)fadeSamples * 2;
 
             if (sample > numSamples)
             {
                 position = endPosition;
+                rampVolume = endRamp;
 
                 if (sample > numSamples + count)
                 {
@@ -123,8 +134,8 @@ class FunstimSampleProvider : ISampleProvider
             float left = (float)radsPerSample.Aggregate(0.0, (a, r) => a + Math.Sin(sampleCount * r));
             float right = -(float)radsPerSample.Aggregate(0.0, (a, r) => a + Math.Sin(sampleCount * r + ((position * speedMultiplier) / 99.0) * Math.PI));
 
-            buffer[offset + i * 2] = (volume * left * 0.9f) / radsPerSample.Count;
-            buffer[offset + i * 2 + 1] = (volume * right * 0.9f) / radsPerSample.Count;
+            buffer[offset + i * 2] = (rampVolume * volume * left * 0.9f) / radsPerSample.Count;
+            buffer[offset + i * 2 + 1] = (rampVolume * volume * right * 0.9f) / radsPerSample.Count;
 
             sampleCount++;
         }

--- a/ScriptPlayer/ScriptPlayer.Shared/Devices/Estim/FunstimSampleProvider.cs
+++ b/ScriptPlayer/ScriptPlayer.Shared/Devices/Estim/FunstimSampleProvider.cs
@@ -42,7 +42,7 @@ class FunstimSampleProvider : ISampleProvider
     {
         int diff = Math.Abs((int)timer.ElapsedMilliseconds - this.durationMs);
 
-        if (diff > 100 || startPosition != this.endPosition)
+        if (diff > 100 || Math.Abs(startPosition - this.endPosition)>10)
         {
             Debug.WriteLine("diff: " + diff);
             Debug.WriteLine("start: " + startPosition + ", previous end: " + this.endPosition);

--- a/ScriptPlayer/ScriptPlayer.Shared/Scripts/ScriptAction.cs
+++ b/ScriptPlayer/ScriptPlayer.Shared/Scripts/ScriptAction.cs
@@ -7,6 +7,7 @@ namespace ScriptPlayer.Shared.Scripts
     {
         [JsonIgnore]
         public TimeSpan TimeStamp;
+        public TimeSpan MediaDuration;
 
         [JsonIgnore]
         public bool OriginalAction { get; set; }

--- a/ScriptPlayer/ScriptPlayer.Shared/Scripts/ScriptHandler.cs
+++ b/ScriptPlayer/ScriptPlayer.Shared/Scripts/ScriptHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -688,6 +689,8 @@ namespace ScriptPlayer.Shared.Scripts
 
                 if (passedIndex > 0)
                     args.RawPreviousAction = _filledActions[passedIndex - 1];
+
+                Debug.WriteLine($"{DateTime.Now:HH:mm:ss.fff}: Action");
 
                 OnScriptActionRaised(args);
             }

--- a/ScriptPlayer/ScriptPlayer/Dialogs/SettingsDialog.xaml
+++ b/ScriptPlayer/ScriptPlayer/Dialogs/SettingsDialog.xaml
@@ -138,6 +138,12 @@
                             </DockPanel>
 
                             <DockPanel>
+                                <TextBlock Style="{StaticResource SettingName}" Text="Ramp Intensity"/>
+                                <TextBlock Style="{StaticResource SettingValue}" Text="{Binding Path=Settings.FunstimRamp, StringFormat={}{0:f0} %}"/>
+                                <Slider Value="{Binding Path=Settings.FunstimRamp}" Margin="8,4" Minimum="0" Maximum="100" SmallChange="1" LargeChange="10" IsSnapToTickEnabled="False" TickFrequency="100"/>
+                            </DockPanel>
+
+                            <DockPanel>
                                 <CheckBox Margin="128,0" IsChecked="{Binding Settings.FunstimFadeOnPause}" Content="Fade out during pauses"/>
                             </DockPanel>
                         </StackPanel>

--- a/ScriptPlayer/ScriptPlayer/ViewModels/MainViewModel.cs
+++ b/ScriptPlayer/ScriptPlayer/ViewModels/MainViewModel.cs
@@ -2717,6 +2717,7 @@ namespace ScriptPlayer.ViewModels
             controller.SetDevice(dialog.SelectedDevice, new FunstimParameters() {
                 Frequencies = Settings.FunstimFrequencies,
                 FadeMs = Settings.FunstimFadeMs,
+                RampPercent = Settings.FunstimRamp,
                 FadeOnPause = Settings.FunstimFadeOnPause,
             });
         }
@@ -3668,6 +3669,8 @@ namespace ScriptPlayer.ViewModels
                     SpeedMultiplier = Settings.SpeedMultiplier,
                     SpeedMin = Settings.MinSpeed / 99.0,
                     SpeedMax = Settings.MaxSpeed / 99.0,
+                    TimeStamp = eventArgs.CurrentAction.TimeStamp,
+                    MediaDuration = TimeSource.Duration,
                 };
 
                 SetDevices(info);

--- a/ScriptPlayer/ScriptPlayer/ViewModels/SettingsViewModel.cs
+++ b/ScriptPlayer/ScriptPlayer/ViewModels/SettingsViewModel.cs
@@ -250,6 +250,7 @@ namespace ScriptPlayer.ViewModels
         private string _estimAudioDevice;
         private string _funstimFrequencies = "420,520,620";
         private TimeSpan _funstimFadeMs = TimeSpan.FromMilliseconds(1000);
+        private int _funstimRamp = 0;
         private bool _funstimFadeOnPause;
         private TimeSpan _audioDelay;
         private string _deoVrEndpoint;
@@ -957,6 +958,26 @@ namespace ScriptPlayer.ViewModels
                 OnPropertyChanged();
             }
         }
+
+        [XmlElement("FunstimRamp")]
+        public int FunstimFadeRampWrapper
+        {
+            get => _funstimRamp;
+            set => FunstimRamp = value;
+        }
+
+        [XmlIgnore]
+        public int FunstimRamp
+        {
+            get => _funstimRamp;
+            set
+            {
+                if (value.Equals(_funstimRamp)) return;
+                _funstimRamp = value;
+                OnPropertyChanged();
+            }
+        }
+
 
         [XmlElement("CommandDelay")]
         public long CommandDelayWrapper


### PR DESCRIPTION
Hi there :) 

This is my first attempt at adding a feature to ScriptPlayer.

This commit adds an experimental feature that allows a gradual ramping up of the intensity of the FunStim device output over the duration of a video. It adds a new setting in the funscript converter settings dialog, and a few changes throughout the entire event chain making it possible to pass through the total duration of the currently playing file. 

I have literally no idea if that's the best way to implement this feature - I tried to go with the existing design and be as minimally invasive as I can. But I'm almost certain I've forgotten some edge cases, and this definitely needs some oversight and testing  :) 
