### PR TITLE
🐛 changing range in settings does not update handy range

### DIFF
--- a/ScriptPlayer/ScriptPlayer/ViewModels/MainViewModel.cs
+++ b/ScriptPlayer/ScriptPlayer/ViewModels/MainViewModel.cs
@@ -1895,6 +1895,7 @@ namespace ScriptPlayer.ViewModels
         private void UpdateAllFromSettings()
         {
             UpdateFilter();
+            UpdateRange();
             UpdateScriptDelay();
             UpdateDeviceSettings();
             UpdateConversionMode();


### PR DESCRIPTION
If you change the range in the settings dialog instead of the settings sidebar the handy does not update the range.
I think this should fix it.

If you don't want me to create PRs just say so ;)