### PR TITLE
Pause video for external players

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+# [Handy FW4 Pre-Release can be found here](https://github.com/FredTungsten/ScriptPlayer/releases/tag/1.2.2)
 # [Latest release can be found here](https://github.com/FredTungsten/ScriptPlayer/releases)
 # [Latest beta can be found here](https://github.com/FredTungsten/ScriptPlayer/wiki/Downloading-Beta-Builds)
 


### PR DESCRIPTION
I added the CheckAndWaitForDevices in the VideoFileOpened Event.
This also gets rid of the issue I had that I had. Handy loaded the script but did not start moving until I clicked somewhere in the timeline of the video.
I'm not sure about other players and other devices but it's tested with VLC and Handy (directly connected)

If this may cause problems just close the PR. 