### PR TITLE
Use a class for PutMode instead of generic string

### DIFF
--- a/ScriptPlayer/ScriptPlayer.HandyApi/HandyApiV3.cs
+++ b/ScriptPlayer/ScriptPlayer.HandyApi/HandyApiV3.cs
@@ -54,10 +54,10 @@ namespace ScriptPlayer.HandyApi
             return await Get<GetModeResult>("mode");
         }
 
-        public async Task<Response<string>> PutMode(HandyModes mode)
+        public async Task<Response<ModeResponse>> PutMode(HandyModes mode)
         {
             PutModeRequest request = new PutModeRequest { Mode = (int)mode };
-            return await Put<string>("mode", request);
+            return await Put<ModeResponse>("mode", request);
         }
 
         public async Task<Response<ConnectedResponse>> GetConnected()
@@ -249,7 +249,7 @@ namespace ScriptPlayer.HandyApi
                 throw new Exception("HTTP Status <> 200 OK");
 
             string responseContent = await responseMessage.Content.ReadAsStringAsync();
-
+            
             Response<T> response = JsonConvert.DeserializeObject<Response<T>>(responseContent);
 
             response.RateLimitPerMinute = TryToParseHeaderToInt(responseMessage.Headers, "X-RateLimit-Limit", 0);

--- a/ScriptPlayer/ScriptPlayer.HandyApi/Messages/Info/InfoRequest.cs
+++ b/ScriptPlayer/ScriptPlayer.HandyApi/Messages/Info/InfoRequest.cs
@@ -73,6 +73,14 @@ namespace ScriptPlayer.HandyApi.Messages
         Vibrate = 8,
     }
 
+    public class ModeResponse
+    {
+        [JsonProperty("mode")]
+        public int Mode { get; set; }
+        [JsonProperty("mode_session_id")]
+        public int ModeSessionId { get; set; }
+    }
+
     public class ConnectedResponse
     {
         [JsonProperty("connected")]


### PR DESCRIPTION
After the latest windows update ScriptPlayer crashes when trying to deserialize the response for PutMode.
This fixes it (tested locally)