### PR TITLE
use mode2 endpoint instead of deprecated mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # [Handy FW4 Pre-Release can be found here](https://github.com/FredTungsten/ScriptPlayer/releases/tag/1.2.3)
-Includes a fix for Windows 11 25H2
 # [Latest release can be found here](https://github.com/FredTungsten/ScriptPlayer/releases)
 # [Latest beta can be found here](https://github.com/FredTungsten/ScriptPlayer/wiki/Downloading-Beta-Builds)
 

--- a/ScriptPlayer/ScriptPlayer.HandyApi/HandyApiV3.cs
+++ b/ScriptPlayer/ScriptPlayer.HandyApi/HandyApiV3.cs
@@ -55,7 +55,7 @@ namespace ScriptPlayer.HandyApi
             return await Get<GetModeResult>("mode");
         }
 
-        public async Task<Response<string>> PutMode(HandyModes mode)
+        public async Task<Response<ModeResponse>> PutMode(HandyModes mode)
         {
             PutModeRequest request = new PutModeRequest { Mode = (int)mode };
             return await Put<ModeResponse>("mode2", request);

--- a/ScriptPlayer/ScriptPlayer.HandyApi/HandyApiV3.cs
+++ b/ScriptPlayer/ScriptPlayer.HandyApi/HandyApiV3.cs
@@ -57,7 +57,7 @@ namespace ScriptPlayer.HandyApi
         public async Task<Response<ModeResponse>> PutMode(HandyModes mode)
         {
             PutModeRequest request = new PutModeRequest { Mode = (int)mode };
-            return await Put<ModeResponse>("mode", request);
+            return await Put<ModeResponse>("mode2", request);
         }
 
         public async Task<Response<ConnectedResponse>> GetConnected()

--- a/ScriptPlayer/ScriptPlayer.HandyApi/Messages/Info/InfoRequest.cs
+++ b/ScriptPlayer/ScriptPlayer.HandyApi/Messages/Info/InfoRequest.cs
@@ -73,6 +73,14 @@ namespace ScriptPlayer.HandyApi.Messages
         Vibrate = 8,
     }
 
+    public class ModeResponse
+    {
+        [JsonProperty("mode")]
+        public int Mode { get; set; }
+        [JsonProperty("mode_session_id")]
+        public int ModeSessionId { get; set; }
+    }
+
     public class ConnectedResponse
     {
         [JsonProperty("connected")]


### PR DESCRIPTION
Using the new mode2 endpoint

(locally tested)